### PR TITLE
API key handling

### DIFF
--- a/thingspeak/__init__.py
+++ b/thingspeak/__init__.py
@@ -96,7 +96,7 @@ class Channel(object):
         <https://de.mathworks.com/help/thingspeak/view-a-channel.html>`_
         """
         options = dict()
-        if self.user_key is not None:
+        if self.user_api_key is not None:
             options["api_key"] = self.user_api_key
         url = "{server_url}/channels/{id}{fmt}".format(
             server_url=self.server_url, id=self.id, fmt=self.fmt

--- a/thingspeak/__init__.py
+++ b/thingspeak/__init__.py
@@ -120,6 +120,28 @@ class Channel(object):
         r = requests.get(url, params=options, timeout=self.timeout)
         return self._fmt(r)
 
+    def get_api_keys(self):
+        """Get Read/Write API Keys a Channel
+
+        `control-a-channel
+        <https://se.mathworks.com/help/thingspeak/channel-control.html>`_
+        """
+        import json
+        v_json = self.view()
+        v = json.loads(v_json)
+        read_api_key = None
+        write_api_key = None
+        for k in v['api_keys']:
+            if k['write_flag']:
+                if write_api_key is None:
+                    write_api_key = k['api_key']
+            else:
+                if read_api_key is None:
+                    read_api_key = k['api_key']        
+        setattr(self,'read_api_key', read_api_key)
+        setattr(self,'write_api_key', write_api_key)
+        return read_api_key, write_api_key
+
     def update(self, data):
         """Update channel feed.
 

--- a/thingspeak/__init__.py
+++ b/thingspeak/__init__.py
@@ -9,13 +9,17 @@ class Channel(object):
     def __init__(
         self,
         id,
-        api_key=None,
+        user_api_key=None,
+        read_api_key=None,
+        write_api_key=None,
         fmt="json",
         timeout=None,
         server_url="https://api.thingspeak.com",
     ):
         self.id = id
-        self.api_key = api_key
+        self.user_api_key = user_api_key
+        self.read_api_key = read_api_key
+        self.write_api_key = write_api_key
         self.fmt = ("." + fmt) if fmt in ["json", "xml"] else ""
         self.timeout = timeout
         self.server_url = server_url
@@ -28,8 +32,8 @@ class Channel(object):
         """
         if options is None:
             options = dict()
-        if self.api_key is not None:
-            options["api_key"] = self.api_key
+        if self.read_api_key is not None:
+            options["api_key"] = self.read_api_key
         url = "{server_url}/channels/{id}/feeds{fmt}".format(
             server_url=self.server_url, id=self.id, fmt=self.fmt
         )
@@ -44,8 +48,8 @@ class Channel(object):
         """
         if options is None:
             options = dict()
-        if self.api_key is not None:
-            options["api_key"] = self.api_key
+        if self.read_api_key is not None:
+            options["api_key"] = self.read_api_key
         url = "{server_url}/channels/{id}/fields/{field}{fmt}".format(
             server_url=self.server_url, id=self.id, field=field, fmt=self.fmt
         )
@@ -60,8 +64,8 @@ class Channel(object):
         """
         if options is None:
             options = dict()
-        if self.api_key is not None:
-            options["api_key"] = self.api_key
+        if self.read_api_key is not None:
+            options["api_key"] = self.read_api_key
         url = "{server_url}/channels/{id}/fields/{field}/last{fmt}".format(
             server_url=self.server_url, id=self.id, field=field, fmt=self.fmt
         )
@@ -76,8 +80,8 @@ class Channel(object):
         """
         if options is None:
             options = dict()
-        if self.api_key is not None:
-            options["api_key"] = self.api_key
+        if self.read_api_key is not None:
+            options["api_key"] = self.read_api_key
         url = "{server_url}/channels/{id}/fields/{field}/last_data_age{fmt}"
         url = url.format(
             server_url=self.server_url, id=self.id, field=field, fmt=self.fmt
@@ -92,8 +96,8 @@ class Channel(object):
         <https://de.mathworks.com/help/thingspeak/view-a-channel.html>`_
         """
         options = dict()
-        if self.api_key is not None:
-            options["api_key"] = self.api_key
+        if self.user_key is not None:
+            options["api_key"] = self.user_api_key
         url = "{server_url}/channels/{id}{fmt}".format(
             server_url=self.server_url, id=self.id, fmt=self.fmt
         )
@@ -106,10 +110,10 @@ class Channel(object):
         `update-channel-feed
         <https://mathworks.com/help/thingspeak/update-channel-feed.html>`_
         """
-        if self.api_key is not None:
-            data["api_key"] = self.api_key
+        if self.write_api_key is not None:
+            data["api_key"] = self.write_api_key
         else:
-            raise ValueError("Missing api_key")
+            raise ValueError("Missing write api_key")
         url = "{server_url}/update{fmt}".format(
             server_url=self.server_url, id=self.id, fmt=self.fmt
         )

--- a/thingspeak/__init__.py
+++ b/thingspeak/__init__.py
@@ -40,6 +40,22 @@ class Channel(object):
         r = requests.get(url, params=options, timeout=self.timeout)
         return self._fmt(r)
 
+    def get_last(self, options=None):
+        """Get a last entry in channel feed.
+
+        `get-a-channel-feed
+        <https://mathworks.com/help/thingspeak/readlastentry.html>`_
+        """
+        if options is None:
+            options = dict()
+        if self.read_api_key is not None:
+            options["api_key"] = self.read_api_key
+        url = "{server_url}/channels/{id}/feeds/last{fmt}".format(
+            server_url=self.server_url, id=self.id, fmt=self.fmt
+        )
+        r = requests.get(url, params=options, timeout=self.timeout)
+        return self._fmt(r)
+
     def get_field(self, field=None, options=None):
         """Get particular field
 

--- a/thingspeak/__init__.py
+++ b/thingspeak/__init__.py
@@ -109,7 +109,7 @@ class Channel(object):
         """View a Channel
 
         `view-a-channel
-        <https://de.mathworks.com/help/thingspeak/view-a-channel.html>`_
+        <https://mathworks.com/help/thingspeak/view-a-channel.html>`_
         """
         options = dict()
         if self.user_api_key is not None:


### PR DESCRIPTION
Previous API key implementation was faulty and unusable: for private channels there is a difference between User API key (for modifying a channel or viewing its setup), Read API key (reading data) and Write API key (pushing data). 
